### PR TITLE
Connect for Go / Interceptors - authentication

### DIFF
--- a/connect-go-example/cmd/client/main.go
+++ b/connect-go-example/cmd/client/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	connectgoexample "connect-go-example"
 	"context"
 	"log"
 	"net/http"
@@ -12,10 +13,12 @@ import (
 )
 
 func main() {
+	interceptors := connect.WithInterceptors(connectgoexample.NewAuthInterceptor())
+
 	client := greetv1connect.NewGreetServiceClient(
 		http.DefaultClient,
 		"http://localhost:8080",
-		connect.WithGRPC(),
+		interceptors,
 	)
 	res, err := client.Greet(
 		context.Background(),

--- a/connect-go-example/cmd/server/main.go
+++ b/connect-go-example/cmd/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	connectgoexample "connect-go-example"
 	"context"
 	"fmt"
 	"log"
@@ -29,9 +30,11 @@ func (s *GreetServer) Greet(
 }
 
 func main() {
+	interceptors := connect.WithInterceptors(connectgoexample.NewAuthInterceptor())
+
 	greeter := &GreetServer{}
 	mux := http.NewServeMux()
-	path, handler := greetv1connect.NewGreetServiceHandler(greeter)
+	path, handler := greetv1connect.NewGreetServiceHandler(greeter, interceptors)
 	mux.Handle(path, handler)
 	http.ListenAndServe(
 		"localhost:8080",

--- a/connect-go-example/simple_authentication.go
+++ b/connect-go-example/simple_authentication.go
@@ -1,0 +1,32 @@
+package connectgoexample
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+)
+
+const tokenHeader = "Acme-Token"
+
+func NewAuthInterceptor() connect.UnaryInterceptorFunc {
+	interceptor := func(next connect.UnaryFunc) connect.UnaryFunc {
+		return connect.UnaryFunc(func(
+			ctx context.Context,
+			req connect.AnyRequest,
+		) (connect.AnyResponse, error) {
+			if req.Spec().IsClient {
+				// Send a token with client requests.
+				req.Header().Set(tokenHeader, "sample")
+			} else if req.Header().Get(tokenHeader) == "" {
+				// Check token in handlers.
+				return nil, connect.NewError(
+					connect.CodeUnauthenticated,
+					errors.New("no token provided"),
+				)
+			}
+			return next(ctx, req)
+		})
+	}
+	return connect.UnaryInterceptorFunc(interceptor)
+}


### PR DESCRIPTION
https://connectrpc.com/docs/go/interceptors

### Server

```
$ go run ./cmd/server/main.go
2023/11/26 17:04:21 Request headers:  map[Accept-Encoding:[gzip] Acme-Token:[sample] Connect-Protocol-Version:[1] Content-Type:[application/proto] Host:[localhost:8080] User-Agent:[connect-go/1.12.0 (go1.20.8)]]
^Csignal: interrupt
```

### Client

```
$ go run ./cmd/client/main.go
2023/11/26 17:04:21 Hello, Jane!
```
